### PR TITLE
Upgrade to use type Msgs []*Msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import (
 	"github.com/jrallison/go-workers"
 )
 
-func myJob(message *workers.Msg) {
+func myJob(message workers.Msgs) {
   // do something with your message
   // message.Jid()
   // message.Args() is a wrapper around go-simplejson (http://godoc.org/github.com/bitly/go-simplejson)
@@ -29,7 +29,7 @@ func myJob(message *workers.Msg) {
 
 type myMiddleware struct{}
 
-func (r *myMiddleware) Call(queue string, message *workers.Msg, next func() bool) (acknowledge bool) {
+func (r *myMiddleware) Call(queue string, message workers.Msgs, next func() bool) (acknowledge bool) {
   // do something before each message is processed
   acknowledge = next()
   // do something after each message is processed
@@ -58,9 +58,6 @@ func main() {
 
   // Add a job to a queue
   workers.Enqueue("myqueue3", "Add", []int{1, 2})
-
-  // Add a job to a queue with retry
-  workers.EnqueueWithOptions("myqueue3", "Add", []int{1, 2}, workers.EnqueueOptions{Retry: true})
 
   // stats will be available at http://localhost:8080/stats
   go workers.StatsServer(8080)

--- a/config.go
+++ b/config.go
@@ -50,7 +50,7 @@ func Configure(options map[string]string) {
 			MaxIdle:     poolSize,
 			IdleTimeout: 240 * time.Second,
 			Dial: func() (redis.Conn, error) {
-				c, err := redis.Dial("tcp", options["server"])
+				c, err := redis.DialTimeout("tcp", options["server"], 5*time.Second, 5*time.Second, 5*time.Second)
 				if err != nil {
 					return nil, err
 				}
@@ -74,7 +74,7 @@ func Configure(options map[string]string) {
 			},
 		},
 		func(queue string) Fetcher {
-			return NewFetch(queue, make(chan *Msg), make(chan bool))
+			return NewFetch(queue, make(chan Msgs), make(chan bool))
 		},
 	}
 }

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -4,6 +4,8 @@ import (
 	"github.com/customerio/gospec"
 	. "github.com/customerio/gospec"
 	"github.com/garyburd/redigo/redis"
+
+	simplejson "github.com/bitly/go-simplejson"
 )
 
 func buildFetch(queue string) Fetcher {
@@ -11,6 +13,29 @@ func buildFetch(queue string) Fetcher {
 	fetch := manager.fetch
 	go fetch.Fetch()
 	return fetch
+}
+
+func buildVirginMessages(args ...string) Msgs {
+	var msgs []*Msg
+	for _, a := range args {
+		b := []byte(a)
+		j, _ := simplejson.NewJson(b)
+		msgs = append(msgs, NewMsg("", j, b))
+	}
+	return msgs
+}
+
+func buildMessages(args ...string) Msgs {
+	var s []string
+	for _, a := range args {
+		b := []byte(a)
+		j, _ := simplejson.NewJson(b)
+		m := NewMsg("", j, b)
+		s = append(s, m.ToJson())
+	}
+
+	messages, _ := NewMsgs(s)
+	return messages
 }
 
 func FetchSpec(c gospec.Context) {
@@ -23,7 +48,7 @@ func FetchSpec(c gospec.Context) {
 	})
 
 	c.Specify("Fetch", func() {
-		message, _ := NewMsg("{\"foo\":\"bar\"}")
+		messages := buildMessages("{\"foo\":\"bar\"}")
 
 		c.Specify("it puts messages from the queues on the messages channel", func() {
 			fetch := buildFetch("fetchQueue2")
@@ -31,12 +56,16 @@ func FetchSpec(c gospec.Context) {
 			conn := Config.Pool.Get()
 			defer conn.Close()
 
-			conn.Do("lpush", "queue:fetchQueue2", message.ToJson())
+			for _, m := range messages {
+				conn.Do("lpush", "queue:fetchQueue2", m.ToJson())
+			}
 
 			fetch.Ready() <- true
-			message := <-fetch.Messages()
+			found := <-fetch.Messages()
 
-			c.Expect(message, Equals, message)
+			c.Expect(len(messages), Equals, 1)
+			c.Expect(len(found), Equals, 1)
+			c.Expect(messages[0].original, Equals, found[0].original)
 
 			len, _ := redis.Int(conn.Do("llen", "queue:fetchQueue2"))
 			c.Expect(len, Equals, 0)
@@ -50,7 +79,9 @@ func FetchSpec(c gospec.Context) {
 			conn := Config.Pool.Get()
 			defer conn.Close()
 
-			conn.Do("lpush", "queue:fetchQueue3", message.ToJson())
+			for _, m := range messages {
+				conn.Do("lpush", "queue:fetchQueue3", m.ToJson())
+			}
 
 			fetch.Ready() <- true
 			<-fetch.Messages()
@@ -58,8 +89,8 @@ func FetchSpec(c gospec.Context) {
 			len, _ := redis.Int(conn.Do("llen", "queue:fetchQueue3:1:inprogress"))
 			c.Expect(len, Equals, 1)
 
-			messages, _ := redis.Strings(conn.Do("lrange", "queue:fetchQueue3:1:inprogress", 0, -1))
-			c.Expect(messages[0], Equals, message.ToJson())
+			found, _ := redis.Strings(conn.Do("lrange", "queue:fetchQueue3:1:inprogress", 0, -1))
+			c.Expect(found[0], Equals, messages[0].ToJson())
 
 			fetch.Close()
 		})
@@ -70,12 +101,14 @@ func FetchSpec(c gospec.Context) {
 			conn := Config.Pool.Get()
 			defer conn.Close()
 
-			conn.Do("lpush", "queue:fetchQueue4", message.ToJson())
+			for _, m := range messages {
+				conn.Do("lpush", "queue:fetchQueue4", m.ToJson())
+			}
 
 			fetch.Ready() <- true
 			<-fetch.Messages()
 
-			fetch.Acknowledge(message)
+			fetch.Acknowledge(messages)
 
 			len, _ := redis.Int(conn.Do("llen", "queue:fetchQueue4:1:inprogress"))
 			c.Expect(len, Equals, 0)
@@ -85,9 +118,9 @@ func FetchSpec(c gospec.Context) {
 
 		c.Specify("removes in progress message when serialized differently", func() {
 			json := "{\"foo\":\"bar\",\"args\":[]}"
-			message, _ := NewMsg(json)
+			messages, _ := NewMsgs([]string{json})
 
-			c.Expect(json, Not(Equals), message.ToJson())
+			c.Expect(json, Not(Equals), messages[0].ToJson())
 
 			fetch := buildFetch("fetchQueue5")
 
@@ -99,7 +132,7 @@ func FetchSpec(c gospec.Context) {
 			fetch.Ready() <- true
 			<-fetch.Messages()
 
-			fetch.Acknowledge(message)
+			fetch.Acknowledge(messages)
 
 			len, _ := redis.Int(conn.Do("llen", "queue:fetchQueue5:1:inprogress"))
 			c.Expect(len, Equals, 0)
@@ -108,28 +141,26 @@ func FetchSpec(c gospec.Context) {
 		})
 
 		c.Specify("refires any messages left in progress from prior instance", func() {
-			message2, _ := NewMsg("{\"foo\":\"bar2\"}")
-			message3, _ := NewMsg("{\"foo\":\"bar3\"}")
+			msgs := buildMessages("{\"foo\":\"bar2\"}", "{\"foo\":\"bar3\"}")
 
 			conn := Config.Pool.Get()
 			defer conn.Close()
 
-			conn.Do("lpush", "queue:fetchQueue6:1:inprogress", message.ToJson())
-			conn.Do("lpush", "queue:fetchQueue6:1:inprogress", message2.ToJson())
-			conn.Do("lpush", "queue:fetchQueue6", message3.ToJson())
+			conn.Do("lpush", "queue:fetchQueue6:1:inprogress", messages[0].ToJson())
+			conn.Do("lpush", "queue:fetchQueue6:1:inprogress", msgs[0].ToJson())
+			conn.Do("lpush", "queue:fetchQueue6", msgs[1].ToJson())
 
 			fetch := buildFetch("fetchQueue6")
 
 			fetch.Ready() <- true
-			c.Expect(<-fetch.Messages(), Equals, message2)
+			c.Expect((<-fetch.Messages())[0].original, Equals, msgs[0].original)
 			fetch.Ready() <- true
-			c.Expect(<-fetch.Messages(), Equals, message)
+			c.Expect((<-fetch.Messages())[0].original, Equals, messages[0].original)
 			fetch.Ready() <- true
-			c.Expect(<-fetch.Messages(), Equals, message3)
+			c.Expect((<-fetch.Messages())[0].original, Equals, msgs[1].original)
 
-			fetch.Acknowledge(message)
-			fetch.Acknowledge(message2)
-			fetch.Acknowledge(message3)
+			fetch.Acknowledge(messages)
+			fetch.Acknowledge(msgs)
 
 			len, _ := redis.Int(conn.Do("llen", "queue:fetchQueue6:1:inprogress"))
 			c.Expect(len, Equals, 0)

--- a/fetcher.go
+++ b/fetcher.go
@@ -10,25 +10,26 @@ import (
 type Fetcher interface {
 	Queue() string
 	Fetch()
-	Acknowledge(*Msg)
+	Acknowledge(Msgs)
 	Ready() chan bool
 	FinishedWork() chan bool
-	Messages() chan *Msg
+	Messages() chan Msgs
 	Close()
 	Closed() bool
+	Cleanup()
 }
 
 type fetch struct {
 	queue        string
 	ready        chan bool
 	finishedwork chan bool
-	messages     chan *Msg
+	messages     chan Msgs
 	stop         chan bool
 	exit         chan bool
 	closed       chan bool
 }
 
-func NewFetch(queue string, messages chan *Msg, ready chan bool) Fetcher {
+func NewFetch(queue string, messages chan Msgs, ready chan bool) Fetcher {
 	return &fetch{
 		queue,
 		ready,
@@ -49,37 +50,45 @@ func (f *fetch) processOldMessages() {
 
 	for _, message := range messages {
 		<-f.Ready()
-		f.sendMessage(message)
+		f.sendMessages([]string{message})
 	}
 }
 
 func (f *fetch) Fetch() {
+	messages := make(chan []string)
+
 	f.processOldMessages()
 
-	go func() {
+	go func(c chan []string) {
 		for {
 			// f.Close() has been called
 			if f.Closed() {
 				break
 			}
 			<-f.Ready()
-			f.tryFetchMessage()
+			f.tryFetchMessage(c)
 		}
-	}()
+	}(messages)
 
+	f.handleMessages(messages)
+}
+
+func (f *fetch) handleMessages(messages chan []string) {
 	for {
 		select {
+		case msgs := <-messages:
+			f.sendMessages(msgs)
 		case <-f.stop:
 			// Stop the redis-polling goroutine
 			close(f.closed)
 			// Signal to Close() that the fetcher has stopped
 			close(f.exit)
-			break
+			return
 		}
 	}
 }
 
-func (f *fetch) tryFetchMessage() {
+func (f *fetch) tryFetchMessage(messages chan []string) {
 	conn := Config.Pool.Get()
 	defer conn.Close()
 
@@ -92,28 +101,31 @@ func (f *fetch) tryFetchMessage() {
 			time.Sleep(1 * time.Second)
 		}
 	} else {
-		f.sendMessage(message)
+		messages <- []string{message}
 	}
 }
 
-func (f *fetch) sendMessage(message string) {
-	msg, err := NewMsg(message)
-
+func (f *fetch) sendMessages(messages []string) {
+	msgs, err := NewMsgs(messages)
 	if err != nil {
-		Logger.Println("ERR: Couldn't create message from", message, ":", err)
+		Logger.Println("ERR:", err)
 		return
 	}
 
-	f.Messages() <- msg
+	f.Messages() <- msgs
 }
 
-func (f *fetch) Acknowledge(message *Msg) {
+func (f *fetch) Acknowledge(messages Msgs) {
 	conn := Config.Pool.Get()
 	defer conn.Close()
-	conn.Do("lrem", f.inprogressQueue(), -1, message.OriginalJson())
+
+	// TODO optimize with a redis lua script
+	for _, m := range messages {
+		conn.Do("lrem", f.inprogressQueue(), -1, string(m.OriginalJson()))
+	}
 }
 
-func (f *fetch) Messages() chan *Msg {
+func (f *fetch) Messages() chan Msgs {
 	return f.messages
 }
 
@@ -153,4 +165,7 @@ func (f *fetch) inprogressMessages() []string {
 
 func (f *fetch) inprogressQueue() string {
 	return fmt.Sprint(f.queue, ":", Config.processId, ":inprogress")
+}
+
+func (f *fetch) Cleanup() {
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,12 @@
+module github.com/customerio/go-workers
+
+go 1.16
+
+require (
+	github.com/bitly/go-simplejson v0.5.0
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/customerio/gospec v0.0.0-20130710230057-a5cc0e48aa39
+	github.com/garyburd/redigo v1.6.2
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/orfjackal/nanospec.go v0.0.0-20120727230329-de4694c1d701 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/bitly/go-simplejson v0.5.0 h1:6IH+V8/tVMab511d5bn4M7EwGXZf9Hj6i2xSwkNEM+Y=
+github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/customerio/gospec v0.0.0-20130710230057-a5cc0e48aa39 h1:O0YTztXI3XeJXlFhSo4wNb0VBVqSgT+hi/CjNWKvMnY=
+github.com/customerio/gospec v0.0.0-20130710230057-a5cc0e48aa39/go.mod h1:OzYUFhPuL2JbjwFwrv6CZs23uBawekc6OZs+g19F0mY=
+github.com/garyburd/redigo v1.6.2 h1:yE/pwKCrbLpLpQICzYTeZ7JsTA/C53wFTJHaEtRqniM=
+github.com/garyburd/redigo v1.6.2/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/orfjackal/nanospec.go v0.0.0-20120727230329-de4694c1d701 h1:yOXfzNV7qkZ3nf2NPqy4BMzlCmnQzIEbI1vuqKb2FkQ=
+github.com/orfjackal/nanospec.go v0.0.0-20120727230329-de4694c1d701/go.mod h1:VtBIF1XX0c1nKkeAPk8i4aXkYopqQgfDqolHUIHPwNI=

--- a/job.go
+++ b/job.go
@@ -1,3 +1,3 @@
 package workers
 
-type jobFunc func(message *Msg)
+type jobFunc func(message Msgs)

--- a/middleware.go
+++ b/middleware.go
@@ -1,7 +1,7 @@
 package workers
 
 type Action interface {
-	Call(queue string, message *Msg, next func() bool) bool
+	Call(queue string, messages Msgs, next func() bool) bool
 }
 
 type Middlewares struct {
@@ -19,17 +19,17 @@ func (m *Middlewares) Prepend(action Action) {
 	m.actions = actions
 }
 
-func (m *Middlewares) call(queue string, message *Msg, final func()) bool {
-	return continuation(m.actions, queue, message, final)()
+func (m *Middlewares) call(queue string, messages Msgs, final func()) bool {
+	return continuation(m.actions, queue, messages, final)()
 }
 
-func continuation(actions []Action, queue string, message *Msg, final func()) func() bool {
+func continuation(actions []Action, queue string, messages Msgs, final func()) func() bool {
 	return func() (acknowledge bool) {
 		if len(actions) > 0 {
 			acknowledge = actions[0].Call(
 				queue,
-				message,
-				continuation(actions[1:], queue, message, final),
+				messages,
+				continuation(actions[1:], queue, messages, final),
 			)
 
 			if !acknowledge {

--- a/middleware_logging.go
+++ b/middleware_logging.go
@@ -8,20 +8,26 @@ import (
 
 type MiddlewareLogging struct{}
 
-func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() bool) (acknowledge bool) {
-	prefix := fmt.Sprint(queue, " JID-", message.Jid())
-
+func (l *MiddlewareLogging) Call(queue string, messages Msgs, next func() bool) (acknowledge bool) {
 	start := time.Now()
-	Logger.Println(prefix, "start")
-	Logger.Println(prefix, "args:", message.Args().ToJson())
+
+	for _, m := range messages {
+		prefix := fmt.Sprint(queue, " JID-", m.Jid())
+
+		Logger.Println(prefix, "start")
+		Logger.Println(prefix, "args: ", m.Args().ToJson())
+	}
 
 	defer func() {
 		if e := recover(); e != nil {
-			Logger.Println(prefix, "fail:", time.Since(start))
+			for _, m := range messages {
+				prefix := fmt.Sprint(queue, " JID-", m.Jid())
+				Logger.Println(prefix, "fail:", time.Since(start))
+			}
 
 			buf := make([]byte, 4096)
 			buf = buf[:runtime.Stack(buf, false)]
-			Logger.Printf("%s error: %v\n%s", prefix, e, buf)
+			Logger.Printf("error: %v\n%s", e, buf)
 
 			panic(e)
 		}
@@ -29,7 +35,10 @@ func (l *MiddlewareLogging) Call(queue string, message *Msg, next func() bool) (
 
 	acknowledge = next()
 
-	Logger.Println(prefix, "done:", time.Since(start))
+	for _, m := range messages {
+		prefix := fmt.Sprint(queue, " JID-", m.Jid())
+		Logger.Println(prefix, "done:", time.Since(start))
+	}
 
 	return
 }

--- a/middleware_retry.go
+++ b/middleware_retry.go
@@ -14,35 +14,37 @@ const (
 
 type MiddlewareRetry struct{}
 
-func (r *MiddlewareRetry) Call(queue string, message *Msg, next func() bool) (acknowledge bool) {
+func (r *MiddlewareRetry) Call(queue string, messages Msgs, next func() bool) (acknowledge bool) {
 	defer func() {
 		if e := recover(); e != nil {
 			conn := Config.Pool.Get()
 			defer conn.Close()
 
-			if retry(message) {
-				message.Set("queue", queue)
-				message.Set("error_message", fmt.Sprintf("%v", e))
-				retryCount := incrementRetry(message)
+			for _, m := range messages {
+				if retry(m) {
+					m.queue = queue
+					m.error = fmt.Sprintf("%v", e)
+					retryCount := incrementRetry(m)
 
-				waitDuration := durationToSecondsWithNanoPrecision(
-					time.Duration(
-						secondsToDelay(retryCount),
-					) * time.Second,
-				)
+					waitDuration := durationToSecondsWithNanoPrecision(
+						time.Duration(
+							secondsToDelay(retryCount),
+						) * time.Second,
+					)
 
-				_, err := conn.Do(
-					"zadd",
-					Config.Namespace+RETRY_KEY,
-					nowToSecondsWithNanoPrecision()+waitDuration,
-					message.ToJson(),
-				)
+					_, err := conn.Do(
+						"zadd",
+						Config.Namespace+RETRY_KEY,
+						nowToSecondsWithNanoPrecision()+waitDuration,
+						m.ToJson(),
+					)
 
-				// If we can't add the job to the retry queue,
-				// then we shouldn't acknowledge the job, otherwise
-				// it'll disappear into the void.
-				if err != nil {
-					acknowledge = false
+					// If we can't add the job to the retry queue,
+					// then we shouldn't acknowledge the job, otherwise
+					// it'll disappear into the void.
+					if err != nil {
+						acknowledge = false
+					}
 				}
 			}
 
@@ -56,34 +58,26 @@ func (r *MiddlewareRetry) Call(queue string, message *Msg, next func() bool) (ac
 }
 
 func retry(message *Msg) bool {
-	retry := false
 	max := DEFAULT_MAX_RETRY
+	retry := message.Retry
+	count := message.retryCount
+	if message.RetryMax != 0 {
+		max = message.RetryMax
 
-	if param, err := message.Get("retry").Bool(); err == nil {
-		retry = param
-	} else if param, err := message.Get("retry").Int(); err == nil {
-		max = param
-		retry = true
 	}
-
-	count, _ := message.Get("retry_count").Int()
-
 	return retry && count < max
 }
 
 func incrementRetry(message *Msg) (retryCount int) {
-	retryCount = 0
-
-	if count, err := message.Get("retry_count").Int(); err != nil {
-		message.Set("failed_at", time.Now().UTC().Format(LAYOUT))
+	t := time.Now().UTC().Format(LAYOUT)
+	if message.retryCount == -1 {
+		message.failedAt = t
 	} else {
-		message.Set("retried_at", time.Now().UTC().Format(LAYOUT))
-		retryCount = count + 1
+		message.retriedAt = t
 	}
+	message.retryCount++
 
-	message.Set("retry_count", retryCount)
-
-	return
+	return message.retryCount
 }
 
 func secondsToDelay(count int) int {

--- a/middleware_stats.go
+++ b/middleware_stats.go
@@ -6,30 +6,30 @@ import (
 
 type MiddlewareStats struct{}
 
-func (l *MiddlewareStats) Call(queue string, message *Msg, next func() bool) (acknowledge bool) {
+func (l *MiddlewareStats) Call(queue string, messages Msgs, next func() bool) (acknowledge bool) {
 	defer func() {
 		if e := recover(); e != nil {
-			incrementStats("failed")
+			incrementStats("failed", len(messages))
 			panic(e)
 		}
 	}()
 
 	acknowledge = next()
 
-	incrementStats("processed")
+	incrementStats("processed", len(messages))
 
 	return
 }
 
-func incrementStats(metric string) {
+func incrementStats(metric string, count int) {
 	conn := Config.Pool.Get()
 	defer conn.Close()
 
 	today := time.Now().UTC().Format("2006-01-02")
 
 	conn.Send("multi")
-	conn.Send("incr", Config.Namespace+"stat:"+metric)
-	conn.Send("incr", Config.Namespace+"stat:"+metric+":"+today)
+	conn.Send("incrby", Config.Namespace+"stat:"+metric, count)
+	conn.Send("incrby", Config.Namespace+"stat:"+metric+":"+today, count)
 
 	if _, err := conn.Do("exec"); err != nil {
 		Logger.Println("couldn't save stats:", err)

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -24,14 +24,14 @@ var order = make([]string, 0)
 type m1 struct{}
 type m2 struct{}
 
-func (m *m1) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (m *m1) Call(queue string, messages Msgs, next func() bool) (result bool) {
 	order = append(order, "m1 enter")
 	result = next()
 	order = append(order, "m1 leave")
 	return
 }
 
-func (m *m2) Call(queue string, message *Msg, next func() bool) (result bool) {
+func (m *m2) Call(queue string, messages Msgs, next func() bool) (result bool) {
 	order = append(order, "m2 enter")
 	result = next()
 	order = append(order, "m2 leave")
@@ -40,7 +40,7 @@ func (m *m2) Call(queue string, message *Msg, next func() bool) (result bool) {
 
 func MiddlewareSpec(c gospec.Context) {
 	middleware := NewMiddleware()
-	message, _ := NewMsg("{\"foo\":\"bar\"}")
+	messages, _ := NewMsgs([]string{"{\"foo\":\"bar\"}"})
 	order = make([]string, 0)
 	first := &m1{}
 	second := &m2{}
@@ -62,7 +62,7 @@ func MiddlewareSpec(c gospec.Context) {
 			middleware.Append(first)
 			middleware.Append(second)
 
-			middleware.call("myqueue", message, func() {
+			middleware.call("myqueue", messages, func() {
 				order = append(order, "job")
 			})
 
@@ -84,7 +84,7 @@ func MiddlewareSpec(c gospec.Context) {
 			middleware.Prepend(first)
 			middleware.Prepend(second)
 
-			middleware.call("myqueue", message, func() {
+			middleware.call("myqueue", messages, func() {
 				order = append(order, "job")
 			})
 

--- a/msg.go
+++ b/msg.go
@@ -1,17 +1,68 @@
 package workers
 
 import (
-	"github.com/bitly/go-simplejson"
+	"encoding/json"
+	"fmt"
 	"reflect"
+	"strconv"
+
+	simplejson "github.com/bitly/go-simplejson"
 )
+
+type Msgs []*Msg
+
+func NewMsgs(messages []string) ([]*Msg, error) {
+	msgs := make(Msgs, 0, len(messages))
+
+	for _, m := range messages {
+		if m, err := NewMsgFromString(m); err != nil {
+			return nil, err
+		} else {
+			msgs = append(msgs, m)
+		}
+	}
+
+	return msgs, nil
+}
 
 type data struct {
 	*simplejson.Json
+	data []byte
+}
+
+func (d data) ToJson() string {
+	return string(d.data)
+}
+
+// For gospec only.
+func (d *data) Equals(other interface{}) bool {
+	otherJson := reflect.ValueOf(other).MethodByName("ToJson").Call([]reflect.Value{})
+	return d.ToJson() == otherJson[0].String()
 }
 
 type Msg struct {
-	*data
+	jid        string
+	Retry      bool
+	RetryMax   int
+	queue      string
+	enqueuedAt float64
+	error      string
+	retryCount int
+	failedAt   string
+	retriedAt  string
+
+	// The original json if the message was created with NewMsgFromString
 	original string
+
+	// The job arguments.
+	args *data
+}
+
+var defaultArgs = []byte("[]")
+var defaultArgsJson *simplejson.Json
+
+func init() {
+	defaultArgsJson, _ = simplejson.NewJson(defaultArgs)
 }
 
 type Args struct {
@@ -19,49 +70,94 @@ type Args struct {
 }
 
 func (m *Msg) Jid() string {
-	return m.Get("jid").MustString()
+	return m.jid
 }
 
 func (m *Msg) Args() *Args {
-	if args, ok := m.CheckGet("args"); ok {
-		return &Args{&data{args}}
-	} else {
-		d, _ := newData("[]")
-		return &Args{d}
+	if m.args == nil {
+		m.args = &data{defaultArgsJson, defaultArgs}
 	}
+	return &Args{m.args}
+}
+
+func (m *Msg) RetryAttempt() int {
+	return m.retryCount
 }
 
 func (m *Msg) OriginalJson() string {
 	return m.original
 }
 
-func (d *data) ToJson() string {
-	json, err := d.Encode()
-
-	if err != nil {
-		Logger.Println("ERR: Couldn't generate json from", d, ":", err)
+func (m *Msg) ToJson() string {
+	args := m.Args()
+	d := map[string]interface{}{
+		"jid":           m.jid,
+		"queue":         m.queue,
+		"retry_count":   m.retryCount,
+		"enqueued_at":   m.enqueuedAt,
+		"error_message": m.error,
+		"failed_at":     m.failedAt,
+		"retried_at":    m.retriedAt,
+		"args":          args.Json,
 	}
+	if m.RetryMax > 0 {
+		d["retry"] = json.Number(strconv.Itoa(m.RetryMax))
+	} else {
+		d["retry"] = m.Retry
+	}
+	json, _ := json.Marshal(d)
 
 	return string(json)
 }
 
-func (d *data) Equals(other interface{}) bool {
-	otherJson := reflect.ValueOf(other).MethodByName("ToJson").Call([]reflect.Value{})
-	return d.ToJson() == otherJson[0].String()
+// NsgMsgFromString creates a new message from the redis retry queue.
+func NewMsgFromString(str string) (*Msg, error) {
+	json, err := simplejson.NewJson([]byte(str))
+	if err != nil {
+		return nil, fmt.Errorf("Couldn't create message from %v: %v", str, err)
+	}
+
+	m := &Msg{
+		jid:        json.Get("jid").MustString(),
+		queue:      json.Get("queue").MustString(),
+		enqueuedAt: json.Get("enqueued_at").MustFloat64(),
+		error:      json.Get("error_message").MustString(),
+		failedAt:   json.Get("failed_at").MustString(),
+		retriedAt:  json.Get("retried_at").MustString(),
+		original:   str,
+	}
+
+	if args := json.Get("args"); args.Interface() != nil {
+		b, _ := args.MarshalJSON()
+		m.args = &data{args, b}
+	}
+
+	if param, err := json.Get("retry_count").Int(); err == nil {
+		m.retryCount = param
+	} else {
+		m.retryCount = -1
+	}
+
+	// Retry is either a bool or a number for hysterical reasons.
+	if param, err := json.Get("retry").Bool(); err == nil {
+		m.Retry = param
+	} else if param, err := json.Get("retry").Int(); err == nil {
+		m.RetryMax = param
+		m.Retry = true
+	}
+
+	return m, nil
 }
 
-func NewMsg(content string) (*Msg, error) {
-	if d, err := newData(content); err != nil {
-		return nil, err
-	} else {
-		return &Msg{d, content}, nil
+// NewMsg creates a new virgin message.
+func NewMsg(jid string, args *simplejson.Json, b []byte) *Msg {
+	m := &Msg{
+		jid:        jid,
+		Retry:      true,
+		retryCount: -1,
 	}
-}
-
-func newData(content string) (*data, error) {
-	if json, err := simplejson.NewJson([]byte(content)); err != nil {
-		return nil, err
-	} else {
-		return &data{json}, nil
+	if args != nil {
+		m.args = &data{args, b}
 	}
+	return m
 }

--- a/msg_test.go
+++ b/msg_test.go
@@ -6,32 +6,20 @@ import (
 )
 
 func MsgSpec(c gospec.Context) {
-	c.Specify("NewMsg", func() {
-		c.Specify("unmarshals json", func() {
-			msg, _ := NewMsg("{\"hello\":\"world\",\"foo\":3}")
-			hello, _ := msg.Get("hello").String()
-			foo, _ := msg.Get("foo").Int()
-
-			c.Expect(hello, Equals, "world")
-			c.Expect(foo, Equals, 3)
-		})
-
-		c.Specify("returns an error if invalid json", func() {
-			msg, err := NewMsg("{\"hello:\"world\",\"foo\":3}")
-
-			c.Expect(msg, IsNil)
-			c.Expect(err, Not(IsNil))
-		})
-	})
-
 	c.Specify("Args", func() {
 		c.Specify("returns args key", func() {
-			msg, _ := NewMsg("{\"hello\":\"world\",\"args\":[\"foo\",\"bar\"]}")
+			msg := buildVirginMessages("[\"foo\",\"bar\"]")[0]
 			c.Expect(msg.Args().ToJson(), Equals, "[\"foo\",\"bar\"]")
 		})
 
 		c.Specify("returns empty array if args key doesn't exist", func() {
-			msg, _ := NewMsg("{\"hello\":\"world\"}")
+			msg, _ := NewMsgFromString("{}}")
+			//"", nil, nil)
+			c.Expect(msg.Args().ToJson(), Equals, "[]")
+		})
+
+		c.Specify("returns empty array if args key doesn't exist", func() {
+			msg := NewMsg("", nil, nil)
 			c.Expect(msg.Args().ToJson(), Equals, "[]")
 		})
 	})

--- a/scheduled_test.go
+++ b/scheduled_test.go
@@ -18,9 +18,9 @@ func ScheduledSpec(c gospec.Context) {
 
 		now := nowToSecondsWithNanoPrecision()
 
-		message1, _ := NewMsg("{\"queue\":\"default\",\"foo\":\"bar1\"}")
-		message2, _ := NewMsg("{\"queue\":\"myqueue\",\"foo\":\"bar2\"}")
-		message3, _ := NewMsg("{\"queue\":\"default\",\"foo\":\"bar3\"}")
+		message1, _ := NewMsgFromString("{\"queue\":\"default\",\"args\":{\"foo\":\"bar1\"}}")
+		message2, _ := NewMsgFromString("{\"queue\":\"myqueue\",\"args\":{\"foo\":\"bar2\"}}")
+		message3, _ := NewMsgFromString("{\"queue\":\"default\",\"args\":{\"foo\":\"bar3\"}}")
 
 		conn.Do("zadd", "prod:"+RETRY_KEY, now-60.0, message1.ToJson())
 		conn.Do("zadd", "prod:"+RETRY_KEY, now-10.0, message2.ToJson())

--- a/stats.go
+++ b/stats.go
@@ -11,8 +11,6 @@ type stats struct {
 	Processed int         `json:"processed"`
 	Failed    int         `json:"failed"`
 	Jobs      interface{} `json:"jobs"`
-	Enqueued  interface{} `json:"enqueued"`
-	Retries   int64       `json:"retries"`
 }
 
 func Stats(w http.ResponseWriter, req *http.Request) {
@@ -20,19 +18,18 @@ func Stats(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 
 	jobs := make(map[string][]*map[string]interface{})
-	enqueued := make(map[string]string)
 
 	for _, m := range managers {
 		queue := m.queueName()
 		jobs[queue] = make([]*map[string]interface{}, 0)
-		enqueued[queue] = ""
+
 		for _, worker := range m.workers {
-			message := worker.currentMsg
+			messages := worker.currentMsgs
 			startedAt := worker.startedAt
 
-			if message != nil && startedAt > 0 {
+			if messages != nil && startedAt > 0 {
 				jobs[queue] = append(jobs[queue], &map[string]interface{}{
-					"message":    message,
+					"messages":   messages,
 					"started_at": startedAt,
 				})
 			}
@@ -43,8 +40,6 @@ func Stats(w http.ResponseWriter, req *http.Request) {
 		0,
 		0,
 		jobs,
-		enqueued,
-		0,
 	}
 
 	conn := Config.Pool.Get()
@@ -53,12 +48,6 @@ func Stats(w http.ResponseWriter, req *http.Request) {
 	conn.Send("multi")
 	conn.Send("get", Config.Namespace+"stat:processed")
 	conn.Send("get", Config.Namespace+"stat:failed")
-	conn.Send("zcard", Config.Namespace+RETRY_KEY)
-
-	for key, _ := range enqueued {
-		conn.Send("llen", fmt.Sprintf("%squeue:%s", Config.Namespace, key))
-	}
-
 	r, err := conn.Do("exec")
 
 	if err != nil {
@@ -66,29 +55,13 @@ func Stats(w http.ResponseWriter, req *http.Request) {
 	}
 
 	results := r.([]interface{})
-	if len(results) == (3 + len(enqueued)) {
-		for index, result := range results {
-			if index == 0 && result != nil {
-				stats.Processed, _ = strconv.Atoi(string(result.([]byte)))
-				continue
-			}
-			if index == 1 && result != nil {
-				stats.Failed, _ = strconv.Atoi(string(result.([]byte)))
-				continue
-			}
 
-			if index == 2 && result != nil {
-				stats.Retries = result.(int64)
-				continue
-			}
-
-			queueIndex := 0
-			for key, _ := range enqueued {
-				if queueIndex == (index - 3) {
-					enqueued[key] = fmt.Sprintf("%d", result.(int64))
-				}
-				queueIndex++
-			}
+	if len(results) == 2 {
+		if results[0] != nil {
+			stats.Processed, _ = strconv.Atoi(string(results[0].([]byte)))
+		}
+		if results[1] != nil {
+			stats.Failed, _ = strconv.Atoi(string(results[1].([]byte)))
 		}
 	}
 

--- a/workers.go
+++ b/workers.go
@@ -14,7 +14,7 @@ const (
 	SCHEDULED_JOBS_KEY = "schedule"
 )
 
-var Logger WorkersLogger = log.New(os.Stdout, "workers: ", log.Ldate|log.Lmicroseconds)
+var Logger WorkersLogger = log.New(os.Stdout, "workers: ", log.Ldate|log.Lmicroseconds|log.Lshortfile)
 
 var managers = make(map[string]*manager)
 var schedule *scheduled

--- a/workers_test.go
+++ b/workers_test.go
@@ -9,7 +9,7 @@ import (
 
 var called chan bool
 
-func myJob(message *Msg) {
+func myJob(message Msgs) {
 	called <- true
 }
 


### PR DESCRIPTION
Modifies `go-workers` to use `[]*Msgs` everywhere instead of `*Msg` to allow for batch processing